### PR TITLE
[Fix] axios 구조 개선 및 인증/일반 API  분리 (#69)

### DIFF
--- a/src/api/axiosApi.ts
+++ b/src/api/axiosApi.ts
@@ -1,0 +1,39 @@
+import axios, { AxiosInstance, InternalAxiosRequestConfig } from "axios";
+
+const axiosApi: AxiosInstance = axios.create({
+  baseURL: "http://52.78.21.91:8080/api",
+  headers: { "Content-Type": "application/json" },
+});
+
+// ✅ 요청 시 accessToken 자동 첨부
+axiosApi.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    const token = localStorage.getItem("accessToken");
+    if (token) config.headers.Authorization = `Bearer ${token}`;
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+// ✅ 공통 에러 처리
+axiosApi.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const status = error.response?.status;
+
+    if (status === 401) {
+      alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+      localStorage.removeItem("accessToken");
+      localStorage.removeItem("refreshToken");
+      window.location.href = "/login";
+    } else if (status === 403) {
+      alert("접근 권한이 없습니다.");
+    } else if (status === 404) {
+      alert("요청한 데이터를 찾을 수 없습니다.");
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default axiosApi;

--- a/src/api/axiosAuth.ts
+++ b/src/api/axiosAuth.ts
@@ -1,0 +1,8 @@
+import axios, { AxiosInstance } from "axios";
+
+const axiosAuth: AxiosInstance = axios.create({
+  baseURL: "http://52.78.21.91:8080", // ✅ /auth 경로용
+  headers: { "Content-Type": "application/json" },
+});
+
+export default axiosAuth;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import axiosInstance from "../api/axiosInstance"; // ✅ 공용 axios 사용
+import axiosAuth from "../api/axiosAuth"; // ✅ 공용 axios 사용
 import "../styles/login.css";
 
 interface LoginResponse {
@@ -18,7 +18,7 @@ const Login: React.FC = () => {
     e.preventDefault();
 
     try {
-      const res = await axiosInstance.post<LoginResponse>("/auth", {
+      const res = await axiosAuth.post<LoginResponse>("/auth", {
         email,
         password,
       });

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import axiosInstance from "../api/axiosInstance";
+import axiosApi from "../api/axiosApi";
 import "../styles/mypage.css";
 import MypageHeader from "../components/MypageHeader";
 import MypageTabs from "../components/MypageTabs";
@@ -23,8 +23,8 @@ const Mypage: React.FC = () => {
   >("review");
 
   useEffect(() => {
-    axiosInstance
-      .get("/api/mypage/profile")
+    axiosApi
+      .get("/mypage/profile")
       .then((res) => setProfile(res.data.data))
       .catch((err) => console.error(err));
   }, []);

--- a/src/pages/RestaurantDetail.tsx
+++ b/src/pages/RestaurantDetail.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import axiosInstance from "../api/axiosInstance";
+import axiosApi from "../api/axiosApi";
 import "../styles/restaurantDetail.css";
 
 // ✅ 백엔드에서 받아올 데이터 구조
@@ -30,7 +30,7 @@ const RestaurantDetail: React.FC = () => {
   useEffect(() => {
     const fetchRestaurant = async () => {
       try {
-        const res = await axiosInstance.get(`/restaurants/${id}`);
+        const res = await axiosApi.get(`/restaurants/${id}`);
         setRestaurant(res.data);
       } catch (err) {
         console.error("식당 상세 조회 실패:", err);

--- a/src/pages/RestaurantForm.tsx
+++ b/src/pages/RestaurantForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import axiosInstance from "../api/axiosInstance";
+import axiosApi from "../api/axiosApi";
 import "../styles/restaurantForm.css";
 
 interface RestaurantFormData {
@@ -31,7 +31,7 @@ const RestaurantForm: React.FC = () => {
 
     const fetchRestaurant = async () => {
       try {
-        const res = await axiosInstance.get(`/restaurants/${id}`);
+        const res = await axiosApi.get(`/restaurants/${id}`);
         const { name, address, phone, description } = res.data;
         setFormData({ name, address, phone, description });
       } catch (err) {
@@ -57,10 +57,10 @@ const RestaurantForm: React.FC = () => {
 
     try {
       if (isEditMode) {
-        await axiosInstance.put(`/restaurants/${id}`, formData);
+        await axiosApi.put(`/restaurants/${id}`, formData);
         alert("店舗情報を更新しました。");
       } else {
-        await axiosInstance.post("/restaurants", formData);
+        await axiosApi.post("/restaurants", formData);
         alert("新しいレストランを登録しました。");
       }
 

--- a/src/pages/RestaurantList.tsx
+++ b/src/pages/RestaurantList.tsx
@@ -1,7 +1,7 @@
 // src/pages/RestaurantList.tsx
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import axiosInstance from "../api/axiosInstance";
+import axiosApi from "../api/axiosApi";
 import "../styles/restaurantList.css";
 
 interface Restaurant {
@@ -23,7 +23,7 @@ const RestaurantList: React.FC = () => {
   useEffect(() => {
     const fetchRestaurants = async () => {
       try {
-        const res = await axiosInstance.get("/restaurants");
+        const res = await axiosApi.get("/restaurants");
         setRestaurants(res.data);
       } catch (err) {
         console.error("식당 목록 조회 실패:", err);

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import axiosInstance from "../api/axiosInstance";
+import axiosAuth from "../api/axiosAuth";
 import "../styles/signup.css";
 
 interface SignupRequest {
@@ -28,7 +28,7 @@ const Signup: React.FC = () => {
     const payload: SignupRequest = { email, password, name, phone };
 
     try {
-      const res = await axiosInstance.post<SignupResponse>(
+      const res = await axiosAuth.post<SignupResponse>(
         "/api/members/register", // ✅ baseURL 
         payload
       );


### PR DESCRIPTION
## 🧩 개요
기존 `axiosInstance`가 로그인/회원가입 요청(`auth`)과 일반 API(`/api/...`) 요청을 모두 처리하면서
baseURL 구조가 일관되지 않아 혼동이 발생했습니다.  
이를 해결하기 위해 **인증용(`axiosAuth`)** 과 **일반 API용(`axiosApi`)** 인스턴스를 분리하여 
코드의 명확성과 유지보수성을 개선했습니다.

---

## 🧱 주요 구현 내용
- **axiosAuth.ts**
  - baseURL: `http://52.78.21.91:8080`
  - 로그인(`auth`), 회원가입(`/api/members/register`) 등 인증 전 요청 전용
- **axiosApi.ts**
  - baseURL: `http://52.78.21.91:8080/api`
  - 보호된 API(`/restaurants`, `/mypage`, `/members` 등) 전용
  - JWT `accessToken` 자동 첨부 및 401/403/404 공통 에러 처리 포함
- **컴포넌트별 적용 변경**
  - `Login.tsx`, `Signup.tsx` → `axiosAuth` 사용  
  - `RestaurantList.tsx`, `RestaurantDetail.tsx`, `RestaurantForm.tsx`, `Mypage.tsx` → `axiosApi` 사용
- **불필요한 axiosInstance.ts 일단 유지**
  - 추후 필요해질 경우를 위해 파일 유지

---

## ⚙️ 테스트 계획
- 로그인 및 회원가입 요청(`/auth`, `/api/members/register`) 정상 처리 확인
- 로그인 후 보호된 API(`/api/restaurants`, `/api/mypage/profile`) 요청 시  
  accessToken 자동 첨부 및 정상 응답 확인
- 401/403/404 응답 시 인터셉터 공통 에러 처리(alert) 정상 작동 확인

---

## 📌 관련 이슈
Closes #69

