### PR TITLE
[Feat] 레스토랑 리스트 필터링 사이드바 구현 (#81)

### DIFF
--- a/src/components/Sidebar/FilterSidebar.tsx
+++ b/src/components/Sidebar/FilterSidebar.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+
+interface FilterSidebarProps {
+  // 필터 값이 변경될 때 상위 컴포넌트로 전달하는 함수
+  onFilterChange: (filters: {
+    keyword: string;
+    region: string;
+    category: string;
+  }) => void;
+}
+
+const FilterSidebar: React.FC<FilterSidebarProps> = ({ onFilterChange }) => {
+  // 🔹 상태 정의
+  const [keyword, setKeyword] = useState("");
+  const [region, setRegion] = useState("");
+  const [category, setCategory] = useState("");
+
+  // 🔹 “검색 적용” 버튼 클릭 시 상위로 필터 전달
+  const handleApply = () => {
+    // 빈 문자열은 params에서 제거
+    const cleaned = Object.fromEntries(
+      Object.entries({ keyword, region, category }).filter(([_, v]) => v !== "")
+    );
+
+    onFilterChange(cleaned);
+  };
+
+  return (
+    <aside className="filter-sidebar">
+      <h2 className="filter-title">検索フィルター</h2>
+
+      {/* 🔍 키워드 검색 */}
+      <div className="filter-group">
+        <label>キーワード検索</label>
+        <input
+          type="text"
+          placeholder="店名や料理名で検索"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+        />
+      </div>
+
+      {/* 📍 지역 선택 */}
+      <div className="filter-group">
+        <label>地域</label>
+        <select value={region} onChange={(e) => setRegion(e.target.value)}>
+          <option value="">すべての地域</option>
+          <option value="東京都">東京都</option>
+          <option value="神奈川県">神奈川県</option>
+          <option value="千葉県">千葉県</option>
+          <option value="埼玉県">埼玉県</option>
+          <option value="大阪府">大阪府</option>
+          <option value="京都府">京都府</option>
+          <option value="愛知県">愛知県</option>
+          <option value="兵庫県">兵庫県</option>
+          <option value="福岡県">福岡県</option>
+          <option value="北海道">北海道</option>
+          <option value="沖縄県">沖縄県</option>
+        </select>
+      </div>
+
+      {/* 🍣 카테고리 선택 */}
+      <div className="filter-group">
+        <label>カテゴリ</label>
+        <select value={category} onChange={(e) => setCategory(e.target.value)}>
+          <option value="">すべてのカテゴリ</option>
+          <option value="和食">和食</option>
+          <option value="寿司">寿司</option>
+          <option value="ラーメン">ラーメン</option>
+          <option value="焼肉">焼肉</option>
+          <option value="イタリアン">イタリアン</option>
+          <option value="フレンチ">フレンチ</option>
+          <option value="カフェ">カフェ</option>
+          <option value="バー">バー</option>
+        </select>
+      </div>
+
+      <button className="apply-btn" onClick={handleApply}>
+        🔎 検索を適用
+      </button>
+    </aside>
+  );
+};
+
+export default FilterSidebar;

--- a/src/pages/RestaurantList.tsx
+++ b/src/pages/RestaurantList.tsx
@@ -1,7 +1,7 @@
-// src/pages/RestaurantList.tsx
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import axiosApi from "../api/axiosApi";
+import FilterSidebar from "../components/Sidebar/FilterSidebar";
 import "../styles/restaurantList.css";
 
 interface Restaurant {
@@ -9,26 +9,29 @@ interface Restaurant {
   name: string;
   address: string;
   ownerName?: string;
+  category?: string;
 }
 
 const RestaurantList: React.FC = () => {
   const [restaurants, setRestaurants] = useState<Restaurant[]>([]);
+  const [filters, setFilters] = useState({
+    keyword: "",
+    region: "",
+    category: "",
+  });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
 
-  // ✅ 로그인 상태 체크
   const isLoggedIn = !!localStorage.getItem("accessToken");
 
+  // ✅ filters 변경 시마다 API 재호출
   useEffect(() => {
     const fetchRestaurants = async () => {
+      setLoading(true);
       try {
-        const res = await axiosApi.get("/restaurants");
-
-        console.log("📦 /restaurants 응답:", res.data);
-        const restaurantList = res.data.content || [];
-
-        setRestaurants(restaurantList);
+        const res = await axiosApi.get("/restaurants", { params: filters });
+        setRestaurants(res.data.content || []);
       } catch (err) {
         console.error("식당 목록 조회 실패:", err);
         setError("データの取得に失敗しました。");
@@ -37,42 +40,57 @@ const RestaurantList: React.FC = () => {
       }
     };
     fetchRestaurants();
-  }, []);
+  }, [filters]);
 
   if (loading) return <p className="loading">読み込み中...</p>;
   if (error) return <p className="error">{error}</p>;
 
   return (
-    <div className="restaurant-list-container">
-      <h2 className="page-title">レストラン一覧</h2>
+    <div className="restaurant-page">
+      {/* 왼쪽 필터 */}
+      <FilterSidebar onFilterChange={setFilters} />
 
-      {/* ✅ 로그인한 사용자에게만 등록 버튼 표시 */}
-      {isLoggedIn && (
-        <button
-          className="register-btn"
-          onClick={() => navigate("/restaurants/new")}
-        >
-          ➕ 新しいレストランを登録
-        </button>
-      )}
-
-      {restaurants.length === 0 ? (
-        <p>登録されたレストランがありません。</p>
-      ) : (
-        <ul className="restaurant-list">
-          {restaurants.map((r) => (
-            <li
-              key={r.id}
-              className="restaurant-item"
-              onClick={() => navigate(`/restaurants/${r.id}`)}
+      {/* 오른쪽 메인 */}
+      <main className="restaurant-main">
+        <div className="list-header">
+          <h2 className="page-title">レストラン一覧</h2>
+          {isLoggedIn && (
+            <button
+              className="register-btn"
+              onClick={() => navigate("/restaurants/new")}
             >
-              <h3>{r.name}</h3>
-              <p>{r.address}</p>
-              {r.ownerName && <p className="owner">オーナー: {r.ownerName}</p>}
-            </li>
-          ))}
-        </ul>
-      )}
+              ➕ 新しいレストランを登録
+            </button>
+          )}
+        </div>
+
+        {restaurants.length === 0 ? (
+          <p>該当するレストランが見つかりません。</p>
+        ) : (
+          <ul className="restaurant-list">
+            {restaurants.map((r) => (
+              <li
+                key={r.id}
+                className="restaurant-card"
+                onClick={() => navigate(`/restaurants/${r.id}`)}
+              >
+                <div className="restaurant-info">
+                  <h3 className="restaurant-name">{r.name}</h3>
+                  <p className="restaurant-address">{r.address}</p>
+                  {r.category && (
+                    <p className="restaurant-category">
+                      カテゴリ: {r.category}
+                    </p>
+                  )}
+                  {r.ownerName && (
+                    <p className="restaurant-owner">オーナー: {r.ownerName}</p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
     </div>
   );
 };

--- a/src/styles/restaurantList.css
+++ b/src/styles/restaurantList.css
@@ -1,55 +1,108 @@
-.restaurant-list-container {
-  padding: 2rem;
+.restaurant-page {
+  display: flex;
+  max-width: 1200px;
+  margin: 40px auto;
+  gap: 24px;
 }
 
-.page-title {
-  text-align: center;
-  margin-bottom: 1.5rem;
-}
-
-.restaurant-list {
-  list-style: none;
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  padding: 0;
-}
-
-.restaurant-item {
-  border: 1px solid #ddd;
-  border-radius: 12px;
-  padding: 1rem;
+/* --- 사이드바 --- */
+.filter-sidebar {
+  width: 25%;
+  border-right: 1px solid #ddd;
+  padding: 20px;
+  position: sticky;
+  top: 80px;
   background-color: #fff;
-  transition: 0.2s;
+  height: fit-content;
+}
+
+.filter-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.filter-group {
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+}
+
+.filter-group label {
+  font-size: 14px;
+  margin-bottom: 6px;
+  font-weight: 500;
+}
+
+.filter-group input,
+.filter-group select {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+}
+
+.apply-btn {
+  width: 100%;
+  padding: 10px;
+  background-color: #f9a825;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
   cursor: pointer;
 }
 
-.restaurant-item:hover {
-  background-color: #f6f6f6;
+.apply-btn:hover {
+  background-color: #f57f17;
 }
 
-.owner {
-  font-size: 0.9rem;
-  color: gray;
+/* --- 메인 리스트 --- */
+.restaurant-main {
+  width: 75%;
+  padding: 20px;
 }
 
-.loading,
-.error {
-  text-align: center;
-  margin-top: 2rem;
+.list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
 }
 
 .register-btn {
-  margin-bottom: 1rem;
-  padding: 0.6rem 1.2rem;
-  background-color: #4caf50;
-  color: #fff;
+  background-color: #0071c2;
+  color: white;
   border: none;
-  border-radius: 8px;
+  padding: 8px 14px;
+  border-radius: 6px;
   cursor: pointer;
-  transition: 0.2s;
 }
 
 .register-btn:hover {
-  background-color: #43a047;
+  background-color: #005da3;
+}
+
+.restaurant-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.restaurant-card {
+  border: 1px solid #eee;
+  border-radius: 10px;
+  padding: 16px;
+  background-color: #fff;
+  transition: box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.restaurant-card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.restaurant-name {
+  font-size: 18px;
+  color: #0040a0;
+  margin-bottom: 4px;
 }


### PR DESCRIPTION
## 🧩 개요
가게 목록을 조회하고, 왼쪽 사이드바에서 검색 및 필터(지역·카테고리)를 통해 조건별로 가게를 조회할 수 있는 페이지를 구현했습니다.  
전체 레이아웃은 타베로그 스타일로 구성되며, 검색어 입력 후 “검색 적용” 버튼을 누르면 필터 조건과 함께 백엔드로 요청이 전송됩니다.

---

## ⚙️ 주요 구현 내용
- **RestaurantList.tsx**
  - 전체 페이지 레이아웃을 구성 (`FilterSidebar` + `RestaurantList` 병렬 배치)
  - Axios를 통해 `/restaurants` API 호출 (filters를 params로 전달)
  - `filters` 상태 변경 시 자동 재요청 (`useEffect` 의존성 활용)
  - 로그인 사용자에게만 “새 레스토랑 등록” 버튼 노출

- **FilterSidebar.tsx**
  - 검색어(`keyword`), 지역(`region`), 카테고리(`category`) 필터 구현
  - 빈 문자열(`""`)은 Axios 요청에서 제외하도록 처리
  - 일본 지역(東京都, 大阪府 등) 및 일본식 카테고리(和食, 寿司 등) 적용
  - “검색 적용” 버튼 클릭 시 `onFilterChange()`로 상위 상태 전달

- **restaurantList.css**
  - 사이드바 고정(`position: sticky`)
  - 카드형 리스트 디자인 (`hover` 시 그림자 효과)
  - 반응형 대응 (너비 1200px 기준)

---

## 관련 이슈
Closes #81 