### PR TITLE
[Feat] 식당 등록 시 카테고리 선택 기능 추가 (#86)

### DIFF
--- a/src/pages/RestaurantForm.tsx
+++ b/src/pages/RestaurantForm.tsx
@@ -6,13 +6,19 @@ import "../styles/restaurantForm.css";
 interface RestaurantFormData {
   name: string;
   address: string;
-  area: string,
+  area: string;
   phone?: string;
   description?: string;
 }
 
+/** ✅ 카테고리 타입 정의 */
+interface Category {
+  id: number;
+  name: string;
+}
+
 const RestaurantForm: React.FC = () => {
-  const { id } = useParams<{ id: string }>(); // 수정 시 존재
+  const { id } = useParams<{ id: string }>(); // 수정 모드 여부
   const navigate = useNavigate();
   const isEditMode = !!id; // id가 있으면 수정 모드
 
@@ -24,18 +30,42 @@ const RestaurantForm: React.FC = () => {
     description: "",
   });
 
-  const [loading, setLoading] = useState(isEditMode); // 수정일 때만 로딩
+  /** ✅ 카테고리 관련 상태 추가 */
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [selectedCategories, setSelectedCategories] = useState<number[]>([]);
+
+  const [loading, setLoading] = useState(isEditMode);
   const [error, setError] = useState<string | null>(null);
 
-  // ✅ 수정 모드일 경우 기존 데이터 불러오기
+  // ✅ 1. 카테고리 목록 불러오기
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const res = await axiosApi.get("/categories");
+        setCategories(res.data);
+      } catch (err) {
+        console.error("카테고리 불러오기 실패:", err);
+      }
+    };
+    fetchCategories();
+  }, []);
+
+  // ✅ 2. 수정 모드일 경우 기존 데이터 불러오기
   useEffect(() => {
     if (!isEditMode) return;
 
     const fetchRestaurant = async () => {
       try {
         const res = await axiosApi.get(`/restaurants/${id}`);
-        const { name, address, area, phone, description } = res.data;
+        const { name, address, area, phone, description, categoryIds } =
+          res.data;
+
         setFormData({ name, address, area, phone, description });
+
+        // ✅ 기존 선택된 카테고리 세팅
+        if (categoryIds && Array.isArray(categoryIds)) {
+          setSelectedCategories(categoryIds);
+        }
       } catch (err) {
         console.error("식당 데이터 로드 실패:", err);
         setError("店舗情報の読み込みに失敗しました。");
@@ -48,22 +78,39 @@ const RestaurantForm: React.FC = () => {
   }, [id]);
 
   // ✅ 입력값 변경 핸들러
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  // ✅ 카테고리 체크박스 핸들러
+  const handleCategoryChange = (categoryId: number) => {
+    setSelectedCategories((prev) =>
+      prev.includes(categoryId)
+        ? prev.filter((id) => id !== categoryId)
+        : [...prev, categoryId]
+    );
   };
 
   // ✅ 등록 / 수정 요청
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    // ✅ categoryIds 추가해서 전송
+    const requestData = {
+      ...formData,
+      categoryIds: selectedCategories,
+    };
+
     try {
       if (isEditMode) {
-        await axiosApi.put(`/restaurants/${id}`, formData);
+        await axiosApi.put(`/restaurants/${id}`, requestData);
         alert("店舗情報を更新しました。");
       } else {
-        console.log("📦 보낼 formData:", formData);
-        await axiosApi.post("/restaurants", formData);
+        console.log("📦 보낼 formData:", requestData);
+        await axiosApi.post("/restaurants", requestData);
         alert("新しいレストランを登録しました。");
       }
 
@@ -103,7 +150,7 @@ const RestaurantForm: React.FC = () => {
             required
           />
         </label>
-        
+
         <label>
           エリア（地域）
           <input
@@ -135,6 +182,23 @@ const RestaurantForm: React.FC = () => {
             rows={4}
           />
         </label>
+
+        {/* ✅ 카테고리 선택 영역 */}
+        <div className="category-section">
+          <p>カテゴリー選択</p>
+          <div className="category-list">
+            {categories.map((cat) => (
+              <label key={cat.id} className="category-item">
+                <input
+                  type="checkbox"
+                  checked={selectedCategories.includes(cat.id)}
+                  onChange={() => handleCategoryChange(cat.id)}
+                />
+                {cat.name}
+              </label>
+            ))}
+          </div>
+        </div>
 
         <button type="submit" className="submit-btn">
           {isEditMode ? "更新する" : "登録する"}

--- a/src/styles/restaurantForm.css
+++ b/src/styles/restaurantForm.css
@@ -48,3 +48,36 @@ textarea {
   text-align: center;
   margin-top: 2rem;
 }
+
+/* ✅ 카테고리 선택 영역 스타일 추가 */
+.category-section {
+  margin-top: 1.5rem;
+}
+
+.category-section p {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.category-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.category-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 6px 10px;
+  background-color: #f9f9f9;
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.category-item:hover {
+  background-color: #eef;
+  border-color: #88a;
+}


### PR DESCRIPTION
## 🧩 주요 구현 내용
1. **카테고리 목록 불러오기**
   - `/categories` API를 통해 전체 카테고리 목록 로드
2. **체크박스 UI 추가**
   - 다중 선택 가능
3. **등록/수정 요청 시 categoryIds 포함**
   - `{ ...formData, categoryIds: selectedCategories }` 구조로 전송

---

## 관련 이슈
Closes #86 