### PR TITLE
[Feat] 가게 운영 시간 프론트 개발(#203)

### DIFF
--- a/src/components/restaurant/RestaurantMain.tsx
+++ b/src/components/restaurant/RestaurantMain.tsx
@@ -1,14 +1,27 @@
-import React from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import axiosApi from "../../api/axiosApi";
 import "/src/styles/restaurantMain.css";
+
+type DayOfWeekType = "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN";
+
+interface RestaurantHoursResponse {
+  dayOfWeek: DayOfWeekType;
+  openTime: string | null; // "09:00:00"
+  closeTime: string | null; // "18:00:00"
+  isOpen: boolean;
+}
 
 interface Props {
   restaurant: {
+    id: number; // ✅ 영업시간 조회용으로 필요
     name: string;
     categoryNames?: string[];
     phone?: string;
     address: string;
     description?: string;
     reservationAvailable?: boolean;
+
+    // ✅ 기존 임시 필드들은 fallback 용도로 유지 가능
     openHours?: string[];
     seatCount?: number;
     averagePrice?: string;
@@ -20,7 +33,155 @@ interface Props {
   };
 }
 
+const ORDER: DayOfWeekType[] = [
+  "MON",
+  "TUE",
+  "WED",
+  "THU",
+  "FRI",
+  "SAT",
+  "SUN",
+];
+
+const DAY_LABELS: Record<DayOfWeekType, string> = {
+  MON: "月",
+  TUE: "火",
+  WED: "水",
+  THU: "木",
+  FRI: "金",
+  SAT: "土",
+  SUN: "日",
+};
+
+function toHHmm(time: string | null | undefined) {
+  if (!time) return "";
+  return time.slice(0, 5); // "09:00:00" -> "09:00"
+}
+
+/**
+ * ✅ 요일별 영업시간을 사람이 읽기 좋게 묶어서 출력
+ * 예)
+ * - 月〜金 09:00〜18:00
+ * - 土 10:00〜20:00
+ * - 日 休み
+ */
+function groupBusinessHours(hours: RestaurantHoursResponse[]): string[] {
+  if (!hours.length) return [];
+
+  const map = new Map<DayOfWeekType, RestaurantHoursResponse>();
+  hours.forEach((h) => map.set(h.dayOfWeek, h));
+
+  // 요일별 "상태 키" 만들기
+  const states = ORDER.map((dow) => {
+    const h = map.get(dow);
+
+    if (!h || !h.isOpen) {
+      return { dow, key: "CLOSED" };
+    }
+
+    const open = toHHmm(h.openTime);
+    const close = toHHmm(h.closeTime);
+
+    if (!open || !close) {
+      return { dow, key: "OPEN|未設定" };
+    }
+
+    return { dow, key: `OPEN|${open}〜${close}` };
+  });
+
+  const result: string[] = [];
+  let buffer: typeof states = [];
+
+  const flush = () => {
+    if (!buffer.length) return;
+
+    const days = buffer.map((b) => b.dow);
+
+    // 연속 요일이면 月〜金 형태로
+    const isContinuous =
+      days.length > 1 &&
+      ORDER.indexOf(days[days.length - 1]) - ORDER.indexOf(days[0]) ===
+        days.length - 1;
+
+    const dayText = isContinuous
+      ? `${DAY_LABELS[days[0]]}〜${DAY_LABELS[days[days.length - 1]]}`
+      : days.map((d) => DAY_LABELS[d]).join("・");
+
+    const key = buffer[0].key;
+
+    if (key === "CLOSED") {
+      result.push(`${dayText} 休み`);
+    } else if (key.startsWith("OPEN|")) {
+      const time = key.replace("OPEN|", "");
+      result.push(`${dayText} ${time}`);
+    }
+
+    buffer = [];
+  };
+
+  states.forEach((s, idx) => {
+    if (buffer.length === 0 || buffer[0].key === s.key) {
+      buffer.push(s);
+    } else {
+      flush();
+      buffer.push(s);
+    }
+
+    if (idx === states.length - 1) flush();
+  });
+
+  return result;
+}
+
+/**
+ * ✅ 정기휴무 문자열 만들기
+ * - CLOSED 요일만 모아서 "月・火" 형태로 표시
+ * - 없으면 "なし"
+ */
+function buildHolidayText(hours: RestaurantHoursResponse[]): string {
+  const closedDays = ORDER.filter((dow) => {
+    const h = hours.find((x) => x.dayOfWeek === dow);
+    return h ? !h.isOpen : false;
+  });
+
+  if (closedDays.length === 0) return "なし";
+  if (closedDays.length === 7) return "毎日休み";
+
+  return closedDays.map((d) => DAY_LABELS[d]).join("・");
+}
+
 const RestaurantMain: React.FC<Props> = ({ restaurant }) => {
+  const [hours, setHours] = useState<RestaurantHoursResponse[] | null>(null);
+
+  // ✅ 영업시간 조회
+  useEffect(() => {
+    if (!restaurant?.id) return;
+
+    const fetchHours = async () => {
+      try {
+        const res = await axiosApi.get(`/restaurants/${restaurant.id}/hours`);
+        setHours(res.data);
+      } catch (e) {
+        console.error("영업시간 조회 실패:", e);
+        setHours(null);
+      }
+    };
+
+    fetchHours();
+  }, [restaurant?.id]);
+
+  // ✅ 영업시간 묶음 출력 (실데이터 우선)
+  const groupedOpenHours = useMemo(() => {
+    if (!hours || hours.length === 0) return null;
+    return groupBusinessHours(hours);
+  }, [hours]);
+
+  // ✅ 정기휴무 출력
+  const holidayView = useMemo(() => {
+    if (!hours || hours.length === 0) return null;
+    return buildHolidayText(hours);
+  }, [hours]);
+
   return (
     <div className="restaurant-info-section">
       <h3 className="section-title">店舗情報</h3>
@@ -68,13 +229,21 @@ const RestaurantMain: React.FC<Props> = ({ restaurant }) => {
           <tr>
             <th>営業時間</th>
             <td>
-              {restaurant.openHours?.length ? (
+              {groupedOpenHours?.length ? (
+                <ul className="open-hours">
+                  {groupedOpenHours.map((line, i) => (
+                    <li key={i}>{line}</li>
+                  ))}
+                </ul>
+              ) : restaurant.openHours?.length ? (
+                // ✅ fallback: 기존 임시 데이터
                 <ul className="open-hours">
                   {restaurant.openHours.map((hour, i) => (
                     <li key={i}>{hour}</li>
                   ))}
                 </ul>
               ) : (
+                // ✅ fallback: 하드코딩 기본값
                 <ul className="open-hours">
                   <li>月〜金 11:30〜22:00</li>
                   <li>土日祝 12:00〜21:30</li>
@@ -85,7 +254,7 @@ const RestaurantMain: React.FC<Props> = ({ restaurant }) => {
 
           <tr>
             <th>定休日</th>
-            <td>{restaurant.holiday ?? "不定休"}</td>
+            <td>{holidayView ?? restaurant.holiday ?? "不定休"}</td>
           </tr>
 
           <tr>
@@ -150,8 +319,9 @@ const RestaurantMain: React.FC<Props> = ({ restaurant }) => {
           <tr>
             <th>紹介文</th>
             <td>
-              {restaurant.description ??
-                "炭火で焼き上げる上質な肉料理と、落ち着いた雰囲気の中でお食事を楽しめます。"}
+              {restaurant.description?.trim()
+                ? restaurant.description
+                : "紹介文が登録されていません。"}
             </td>
           </tr>
         </tbody>

--- a/src/styles/restaurantForm.css
+++ b/src/styles/restaurantForm.css
@@ -81,3 +81,82 @@ textarea {
   background-color: #eef;
   border-color: #88a;
 }
+
+/* ✅ 영업시간 설정 영역 */
+.hours-section {
+  margin-top: 2rem;
+}
+
+.hours-section p {
+  font-weight: bold;
+  margin-bottom: 0.8rem;
+}
+
+/* ✅ 영업시간 테이블 */
+.hours-table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #fafafa;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.hours-table thead {
+  background-color: #f2f2f2;
+}
+
+.hours-table th,
+.hours-table td {
+  padding: 10px;
+  text-align: center;
+  border-bottom: 1px solid #e0e0e0;
+  font-size: 0.95rem;
+}
+
+.hours-table th {
+  font-weight: bold;
+  color: #555;
+}
+
+/* 마지막 줄 border 제거 */
+.hours-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* 요일 컬럼 강조 */
+.hours-table td:first-child {
+  font-weight: bold;
+  color: #333;
+}
+
+/* 체크박스 중앙 정렬 */
+.hours-table input[type="checkbox"] {
+  transform: scale(1.1);
+  cursor: pointer;
+}
+
+/* 시간 input */
+.hours-table input[type="time"] {
+  padding: 4px 6px;
+  font-size: 0.9rem;
+}
+
+/* 비활성화된 시간 input */
+.hours-table input[type="time"]:disabled {
+  background-color: #e9e9e9;
+  color: #999;
+  cursor: not-allowed;
+}
+
+/* 모바일 대응 */
+@media (max-width: 480px) {
+  .hours-table th,
+  .hours-table td {
+    padding: 6px;
+    font-size: 0.85rem;
+  }
+
+  .hours-table input[type="time"] {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## 주요 구현 내용
- 가게 등록 / 수정 페이지
 - 기존 RestaurantForm에 요일별 영업시간 설정 섹션 추가
 - 월~일 7일 고정 UI 구성
 - 요일별:
   - 영업 여부 토글
   - 오픈 시간/마감 시간 입력
 - 등록 시
   - 가게 생성 후 영업시간 초기 세팅 API 연동
 - 수정 시
   - 기존 영업시간 조회 후 수정 API 연동

## 관련 이슈
Closes #203 